### PR TITLE
@rebox: support Lottie React Native setup

### DIFF
--- a/packages/rebox/android/src/link-android-dependency.ts
+++ b/packages/rebox/android/src/link-android-dependency.ts
@@ -6,15 +6,28 @@ export type TLinkAndroidDependencyOptions = {
   dependencyName: string,
 }
 
+const getDependencyAndroidSourcePath = (dependencyPath: string) => {
+  try {
+    const reactNativeConfig = require(path.resolve(
+      path.join(dependencyPath, 'react-native.config.js')
+    ))
+
+    return path.join(dependencyPath, reactNativeConfig.dependency.platforms.android.sourceDir)
+  } catch (e) {
+    return path.join(dependencyPath, 'android')
+  }
+}
+
 export const linkAndroidDependency = async (options: TLinkAndroidDependencyOptions): Promise<void> => {
   const dependencyPath = path.join('node_modules', options.dependencyName)
+  const dependencyAndroidSourcePath = getDependencyAndroidSourcePath(dependencyPath)
 
   // settings.gradle
   const settingsGradlePath = path.join(options.projectPath, 'settings.gradle')
-  const dependencySettingsGradlePath = path.relative(options.projectPath, dependencyPath)
+  const dependencySettingsGradlePath = path.relative(options.projectPath, dependencyAndroidSourcePath)
   let settingGradleData = await readFile(settingsGradlePath, { encoding: 'utf8' })
 
-  settingGradleData = settingGradleData.replace('// REBOX', `include ':${options.dependencyName}'\nproject(':${options.dependencyName}').projectDir = new File(rootProject.projectDir, '${dependencySettingsGradlePath}/android')\n// REBOX`)
+  settingGradleData = settingGradleData.replace('// REBOX', `include ':${options.dependencyName}'\nproject(':${options.dependencyName}').projectDir = new File(rootProject.projectDir, '${dependencySettingsGradlePath}')\n// REBOX`)
 
   await writeFile(settingsGradlePath, settingGradleData)
 
@@ -27,10 +40,10 @@ export const linkAndroidDependency = async (options: TLinkAndroidDependencyOptio
   await writeFile(buildGradlePath, buildGradleData)
 
   // app/src/main/java/com/rebox/MainApplication.java
-  const dependencyManifestPath = path.join(dependencyPath, 'android', 'src', 'main', 'AndroidManifest.xml')
+  const dependencyManifestPath = path.join(dependencyAndroidSourcePath, 'src', 'main', 'AndroidManifest.xml')
   const dependencyManifestData = await readFile(dependencyManifestPath, { encoding: 'utf8' })
   const packageId = /package="(.+)"/.exec(dependencyManifestData)![1]
-  const packageDirFiles = await readdir(path.join(dependencyPath, 'android', 'src', 'main', 'java', ...packageId.split('.')))
+  const packageDirFiles = await readdir(path.join(dependencyAndroidSourcePath, 'src', 'main', 'java', ...packageId.split('.')))
   const packageName = packageDirFiles.find((filename) => filename.endsWith('Package.java'))!.replace('.java', '')
   const mainApplicationJavaPath = path.join(options.projectPath, 'app', 'src', 'main', 'java', 'com', 'rebox', 'MainApplication.java')
   let mainApplicationJavaData = await readFile(mainApplicationJavaPath, { encoding: 'utf8' })

--- a/packages/rebox/ios/ios/Podfile
+++ b/packages/rebox/ios/ios/Podfile
@@ -1,3 +1,4 @@
+use_frameworks!
 platform :ios, '9.0'
 
 target 'rebox' do


### PR DESCRIPTION
Lottie React Native has a couple of differences from React Native SVG as an extension to be added to React Native. This pull request adds support for this different setup.

* **Android**: Lottie React Native uses a [`react-native.config`](https://github.com/react-native-community/lottie-react-native/blob/master/react-native.config.js) file to specify the source dir for Android, unlike React Native SVG that has it placed directly at `react-native-svg/android/`. This PR adds support for using a `react-native.config` file, if available.

* **iOS**: Lottie iOS [requires the declaration `use_frameworks!` to be placed at the top of the `Podfile`](https://github.com/react-native-community/lottie-react-native/issues/536#issuecomment-527786134). I do not know the reason for this, but it works. This PR adds that line to the `Podfile` template in `@rebox/ios`