### PR TITLE
🌱 rebox/native-utils, rebox/web: add support for js and jsx in all file search

### DIFF
--- a/packages/rebox/native-utils/src/haul.config.js
+++ b/packages/rebox/native-utils/src/haul.config.js
@@ -79,11 +79,15 @@ export default makeConfig({
         config.resolve.extensions = [
           ...config.resolve.extensions,
           `.${env.platform}.js`,
+          `.${env.platform}.jsx`,
           `.${env.platform}.ts`,
           `.${env.platform}.tsx`,
           '.native.js',
+          '.native.jsx',
           '.native.ts',
           '.native.tsx',
+          '.js',
+          '.jsx',
           '.ts',
           '.tsx',
         ]

--- a/packages/rebox/web/src/build-web-app-release.ts
+++ b/packages/rebox/web/src/build-web-app-release.ts
@@ -66,6 +66,7 @@ export const buildWebAppRelease = (userOptions: TBuildWebAppReleaseOptions) => {
         '.web.ts',
         '.web.tsx',
         '.js',
+        '.jsx',
         '.ts',
         '.tsx',
         '.json',

--- a/packages/rebox/web/src/run-web-app.ts
+++ b/packages/rebox/web/src/run-web-app.ts
@@ -50,6 +50,7 @@ export const runWebApp = (options: TRunWebAppOptions): Promise<() => Promise<voi
         '.web.ts',
         '.web.tsx',
         '.js',
+        '.jsx',
         '.ts',
         '.tsx',
         '.json',


### PR DESCRIPTION
Before this update only the entrypoint was working with a `.jsx` extension, but the rest of the files still needed to be called `.tsx`.

This update also adds support for `.js` in all instances that `.ts` is supported.