### PR TITLE
🐞 rebox/android: support scoped npm dependencies

### DIFF
--- a/packages/rebox/android/src/link-android-dependency.ts
+++ b/packages/rebox/android/src/link-android-dependency.ts
@@ -19,13 +19,16 @@ const getDependencyAndroidSourcePath = async (dependencyPath: string): Promise<s
 export const linkAndroidDependency = async (options: TLinkAndroidDependencyOptions): Promise<void> => {
   const dependencyPath = path.join('node_modules', options.dependencyName)
   const dependencyAndroidSourcePath = await getDependencyAndroidSourcePath(dependencyPath)
+  const cleanDependencyName = options.dependencyName.indexOf('@') === -1
+    ? options.dependencyName
+    : options.dependencyName.split('/')[1]
 
   // settings.gradle
   const settingsGradlePath = path.join(options.projectPath, 'settings.gradle')
   const dependencySettingsGradlePath = path.relative(options.projectPath, dependencyAndroidSourcePath)
   let settingGradleData = await readFile(settingsGradlePath, { encoding: 'utf8' })
 
-  settingGradleData = settingGradleData.replace('// REBOX', `include ':${options.dependencyName}'\nproject(':${options.dependencyName}').projectDir = new File(rootProject.projectDir, '${dependencySettingsGradlePath}')\n// REBOX`)
+  settingGradleData = settingGradleData.replace('// REBOX', `include ':${cleanDependencyName}'\nproject(':${cleanDependencyName}').projectDir = new File(rootProject.projectDir, '${dependencySettingsGradlePath}')\n// REBOX`)
 
   await writeFile(settingsGradlePath, settingGradleData)
 
@@ -33,7 +36,7 @@ export const linkAndroidDependency = async (options: TLinkAndroidDependencyOptio
   const buildGradlePath = path.join(options.projectPath, 'app', 'build.gradle')
   let buildGradleData = await readFile(buildGradlePath, { encoding: 'utf8' })
 
-  buildGradleData = buildGradleData.replace('// REBOX', `implementation project(':${options.dependencyName}')\n    // REBOX`)
+  buildGradleData = buildGradleData.replace('// REBOX', `implementation project(':${cleanDependencyName}')\n    // REBOX`)
 
   await writeFile(buildGradlePath, buildGradleData)
 


### PR DESCRIPTION
*The problem*

When installing a scoped package dependency, such as `@react-native-community/async-storage`, Android is blowing up:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':@react-native-community/async-storage'.
> The project name '@react-native-community/async-storage' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/6.0.1/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).
```

*The solution*

If the package name has a `@` in it's name, split by `/` and use the second part as the dependency name in the Android configuration files.

*Does it work?*

Tested locally and it's working.