### PR TITLE
🐞 xrom: add `--shm-size=1g` to fix "Out of memory. size=262144" error

### DIFF
--- a/packages/xrom/src/index.ts
+++ b/packages/xrom/src/index.ts
@@ -42,6 +42,7 @@ export const runBrowser = async (options: TRunBrowserOptions): Promise<TRunBrows
     'run',
     '-d',
     '--rm',
+    '--shm-size=1g',
     '-p',
     `${opts.port}:${opts.port}`,
     '-e',


### PR DESCRIPTION
already existing `--disable-dev-shm-usage` Chromium flag doesn't help