### PR TITLE
@auto/core: prompt edit not opening editor

### DIFF
--- a/packages/auto/core/src/prompt/make-prompt.ts
+++ b/packages/auto/core/src/prompt/make-prompt.ts
@@ -50,7 +50,8 @@ export const makePrompt = async (packages: TReadonly<TPackageMap>, bumps: TReado
     await spawnChildProcess(
       `${editor} ${PROMPT_FILE_PATH}`,
       {
-        stdout: null,
+        stdin: process.stdin,
+        stdout: process.stdout,
         stderr: process.stderr,
       }
     )

--- a/packages/auto/core/test/prompt/make-prompt.ts
+++ b/packages/auto/core/test/prompt/make-prompt.ts
@@ -353,7 +353,7 @@ test('makePrompt: edit - no changes made', async (t) => {
       ],
       [
         'editor ./node_modules/@auto/.EDIT.json',
-        { stdout: null, stderr: process.stderr },
+        { stdin: process.stdin, stdout: process.stdout, stderr: process.stderr },
       ],
     ],
     'should call editor'
@@ -471,7 +471,7 @@ test('makePrompt: edit - invalid answer json', async (t) => {
       ],
       [
         'editor ./node_modules/@auto/.EDIT.json',
-        { stdout: null, stderr: process.stderr },
+        { stdin: process.stdin, stdout: process.stdout, stderr: process.stderr },
       ],
     ],
     'should call editor'
@@ -612,7 +612,7 @@ test('makePrompt: edit - changes', async (t) => {
       ],
       [
         'editor ./node_modules/@auto/.EDIT.json',
-        { stdout: null, stderr: process.stderr },
+        { stdin: process.stdin, stdout: process.stdout, stderr: process.stderr },
       ],
     ],
     'should call editor'


### PR DESCRIPTION
## Problem
When trying to edit bumps during publish or testPublish task the script hangs and doesn't open editor (vim in my case).
Two other people were able to reproduce the issue.

## Solution
Setting stdin and stdout to process.stdin and process.stdout for process that spawns editor fixes the issue.
I tried it out by changing the package inside `node_modules` (like a savage :D) and the editor opened, I was able to edit the bumps and the changes were recognized by the tasks.