### PR TITLE
Add `dependencyNames` option to x-ray screenshot ios & android plugins

### DIFF
--- a/packages/x-ray/plugin-android-screenshots/src/plugin.ts
+++ b/packages/x-ray/plugin-android-screenshots/src/plugin.ts
@@ -24,6 +24,7 @@ type TRequest = {
 }
 
 export type TAndroidScreenshotsOptions = {
+  dependencyNames?: string[],
   fontsDir?: string,
   shouldBailout?: boolean,
 }
@@ -47,8 +48,8 @@ export const androidScreenshots = (options?: TAndroidScreenshotsOptions): TPlugi
       appName: 'X-Ray',
       appId: 'org.nextools.xray',
       entryPointPath,
-      fontsDir: options?.fontsDir,
-      dependencyNames: [
+      fontsDir: opts?.fontsDir,
+      dependencyNames: opts?.dependencyNames ?? [
         'react-native-svg',
         'react-native-view-shot',
       ],

--- a/packages/x-ray/plugin-android-screenshots/src/plugin.ts
+++ b/packages/x-ray/plugin-android-screenshots/src/plugin.ts
@@ -36,8 +36,7 @@ export const androidScreenshots = (options?: TAndroidScreenshotsOptions): TPlugi
   getResults: async (files) => {
     const opts = {
       shouldBailout: false,
-      iPhoneVersion: 8,
-      iOSVersion: '13.2',
+      dependencyNames: [],
       ...options,
     }
     const entryPointPath = await rsolve('@x-ray/native-screenshots-app', 'react-native')
@@ -49,9 +48,10 @@ export const androidScreenshots = (options?: TAndroidScreenshotsOptions): TPlugi
       appId: 'org.nextools.xray',
       entryPointPath,
       fontsDir: opts?.fontsDir,
-      dependencyNames: opts?.dependencyNames ?? [
+      dependencyNames: [
         'react-native-svg',
         'react-native-view-shot',
+        ...opts.dependencyNames,
       ],
       portsToForward: [3002],
       isHeadless: true,

--- a/packages/x-ray/plugin-ios-screenshots/src/plugin.ts
+++ b/packages/x-ray/plugin-ios-screenshots/src/plugin.ts
@@ -26,7 +26,7 @@ type TRequest = {
 export type TIosScreenshotsOptions = {
   dependencyNames?: string[],
   fontsDir?: string,
-  iPhoneVersion?: number,
+  iPhoneVersion?: string,
   iOSVersion?: string,
   shouldBailout?: boolean,
 }
@@ -38,8 +38,9 @@ export const iOsScreenshots = (options?: TIosScreenshotsOptions): TPlugin<Uint8A
   getResults: async (files) => {
     const opts = {
       shouldBailout: false,
-      iPhoneVersion: 8,
-      iOSVersion: '13.2',
+      iPhoneVersion: '8',
+      iOSVersion: '13',
+      dependencyNames: [],
       ...options,
     }
     const entryPointPath = await rsolve('@x-ray/native-screenshots-app', 'react-native')
@@ -49,13 +50,14 @@ export const iOsScreenshots = (options?: TIosScreenshotsOptions): TPlugin<Uint8A
     const closeIosApp = await runIosApp({
       appName: 'X-Ray',
       appId: 'org.nextools.x-ray',
-      iPhoneModel: opts?.iPhoneVersion.toString() ?? '8',
-      iOSVersion: opts?.iOSVersion ?? '13',
+      iPhoneModel: opts.iPhoneVersion,
+      iOSVersion: opts.iOSVersion,
       entryPointPath,
       fontsDir: opts?.fontsDir,
-      dependencyNames: opts?.dependencyNames ?? [
+      dependencyNames: [
         'react-native-svg',
         'react-native-view-shot',
+        ...opts.dependencyNames,
       ],
       isHeadless: true,
     })

--- a/packages/x-ray/plugin-ios-screenshots/src/plugin.ts
+++ b/packages/x-ray/plugin-ios-screenshots/src/plugin.ts
@@ -49,8 +49,8 @@ export const iOsScreenshots = (options?: TIosScreenshotsOptions): TPlugin<Uint8A
     const closeIosApp = await runIosApp({
       appName: 'X-Ray',
       appId: 'org.nextools.x-ray',
-      iPhoneModel: '8',
-      iOSVersion: '13',
+      iPhoneModel: opts?.iPhoneVersion.toString() ?? '8',
+      iOSVersion: opts?.iOSVersion ?? '13',
       entryPointPath,
       fontsDir: opts?.fontsDir,
       dependencyNames: opts?.dependencyNames ?? [

--- a/packages/x-ray/plugin-ios-screenshots/src/plugin.ts
+++ b/packages/x-ray/plugin-ios-screenshots/src/plugin.ts
@@ -24,6 +24,7 @@ type TRequest = {
 }
 
 export type TIosScreenshotsOptions = {
+  dependencyNames?: string[],
   fontsDir?: string,
   iPhoneVersion?: number,
   iOSVersion?: string,
@@ -52,7 +53,7 @@ export const iOsScreenshots = (options?: TIosScreenshotsOptions): TPlugin<Uint8A
       iOSVersion: '13',
       entryPointPath,
       fontsDir: opts?.fontsDir,
-      dependencyNames: [
+      dependencyNames: opts?.dependencyNames ?? [
         'react-native-svg',
         'react-native-view-shot',
       ],


### PR DESCRIPTION
Hi there 👋 
When running x-ray screenshots in my project I realized that I need to pass additional dependency to ios and android simulators to run screenshots successfully on my components.

I added `dependencyNames` as a `string[]` to android and ios screenshot plugins and use them respectively in `runAndroidApp` and `runIosApp` if they are not `null` or `undefined`.

I also noticed that ios screenshot function was accepting some options that weren't used later, so I corrected that as well: https://github.com/nextools/metarepo/commit/971be12998b849feca9c4dbf79ab64bb37d64f9d

I test published the changes and tested them in my repository - it worked nicely.