### PR TITLE
🐞 r11y: fix missing `axe-rules.json` in `build/` folder

### DIFF
--- a/packages/r11y/package.json
+++ b/packages/r11y/package.json
@@ -4,6 +4,9 @@
   "description": "Get a11y data of React app",
   "keywords": [],
   "main": "src/index.ts",
+  "buildAssets": {
+    "src/*.json": "node/"
+  },
   "repository": "nextools/metarepo",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Fixes #233 