### PR TITLE
🐣 TypeScript plugin to allow explicit extension in imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "packages/syntx",
     "packages/tarmap",
     "packages/tmpa",
+    "packages/ts-import-ext-plugin",
     "packages/tsfn",
     "packages/typeon",
     "packages/unchunk",

--- a/packages/nextools/typescript-config/tsconfig.json
+++ b/packages/nextools/typescript-config/tsconfig.json
@@ -12,5 +12,8 @@
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "plugins": [
+      { "name": "ts-import-ext-plugin" }
+    ]
   }
 }

--- a/packages/nextools/typescript-esm-loader/test/fixtures/root.ts
+++ b/packages/nextools/typescript-esm-loader/test/fixtures/root.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 // eslint-disable-next-line import/extensions
 import { add } from './dep.ts'
 

--- a/packages/ts-import-ext-plugin/license.md
+++ b/packages/ts-import-ext-plugin/license.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) 2021–present NexTools
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/ts-import-ext-plugin/package.json
+++ b/packages/ts-import-ext-plugin/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ts-import-ext-plugin",
+  "version": "0.0.0",
+  "description": "TypeScript plugin to allow explicit extension in imports",
+  "keywords": [],
+  "main": "src/index.js",
+  "repository": "nextools/metarepo",
+  "license": "MIT",
+  "engines": {
+    "node": ">=12.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "typescript": "^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.0"
+  }
+}

--- a/packages/ts-import-ext-plugin/readme.md
+++ b/packages/ts-import-ext-plugin/readme.md
@@ -1,0 +1,25 @@
+# ts-import-ext-plugin ![npm](https://flat.badgen.net/npm/v/ts-import-ext-plugin)
+
+TypeScript plugin to allow explicit extension in imports, see [TypeScript/issues/38149](https://github.com/microsoft/TypeScript/issues/38149).
+
+## Install
+
+```sh
+$ yarn add ts-import-ext-plugin
+```
+
+## Usage
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      { "name": "ts-import-ext-plugin" }
+    ]
+  }
+}
+```
+
+```ts
+import { foo } from './foo.ts'
+```

--- a/packages/ts-import-ext-plugin/src/index.js
+++ b/packages/ts-import-ext-plugin/src/index.js
@@ -1,0 +1,37 @@
+/* eslint-disable max-params */
+const path = require('path')
+
+const EXT_REGEXPS = [/\.ts$/, /\.tsx$/, /\.js$/, /\.jsx$/]
+
+// https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin
+const init = ({ typescript }) => {
+  const fileExists = (fileName) => typescript.sys.fileExists(fileName)
+
+  return ({
+    create(info) {
+      const origResolveModuleNames = info.languageServiceHost.resolveModuleNames
+
+      info.languageServiceHost.resolveModuleNames = (moduleNames, containingFile, reusedNames, redirectedReference, options) => {
+        const newModuleNames = moduleNames.map((moduleName) => {
+          if (moduleName.startsWith('.') || moduleName.startsWith('/')) {
+            const modulePath = path.join(path.dirname(containingFile), moduleName)
+
+            for (const extRegExp of EXT_REGEXPS) {
+              if (extRegExp.test(moduleName) && fileExists(modulePath)) {
+                return moduleName.replace(extRegExp, '')
+              }
+            }
+          }
+
+          return moduleName
+        })
+
+        return origResolveModuleNames.call(info.languageServiceHost, newModuleNames, containingFile, reusedNames, redirectedReference, options)
+      }
+
+      return info.languageService
+    },
+  })
+}
+
+module.exports = init


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin

>plugins aren't loaded during normal commandline typechecking or emitting, (so are not loaded by tsc)

...