### PR TITLE
Added the option to override where to fetch docker images in xrom

### DIFF
--- a/packages/xrom/readme.md
+++ b/packages/xrom/readme.md
@@ -43,7 +43,7 @@ const browser = await puppeteer.connect({ browserWSEndpoint })
 
 
 ### Overriding the docker root url to another set of browser images
-Incase you want to use your own or some other set of docker images of chromium and/or firefox.
+You can override the root URL to use some other set of docker images of Chromium and/or Firefox.
 
 
 Make sure the final link which is evaluated as `${dockerUrlRoot}/${browser}:${version}` points to a valid public docker image

--- a/packages/xrom/readme.md
+++ b/packages/xrom/readme.md
@@ -14,6 +14,7 @@ $ yarn add xrom
 type TRunBrowserOptions = {
   browser: 'chromium' | 'firefox',
   version: string,
+  dockerUrlRoot?: string
   port?: number,
   fontsDir?: string,
   mountVolumes?: {
@@ -38,4 +39,20 @@ import puppeteer from 'puppeteer-core'
 
 const { browserWSEndpoint } = await runBrowser({ browser: 'chromium' })
 const browser = await puppeteer.connect({ browserWSEndpoint })
+```
+
+
+### Overriding the docker root url to another set of browser images
+Incase you want to use your own or some other set of docker images of chromium and/or firefox.
+
+
+Make sure the final link which is evaluated as `${dockerUrlRoot}/${browser}:${version}` points to a valid public docker image
+
+```js
+const { browserWSEndpoint, closeBrowser } = await runBrowser({
+  dockerUrlRoot: 'ghcr.io/shenato/docker-browser',
+  browser: 'chromium',
+  version: opts.chromiumVersion,
+  fontsDir: opts.fontsDir,
+})
 ```

--- a/packages/xrom/readme.md
+++ b/packages/xrom/readme.md
@@ -46,7 +46,7 @@ const browser = await puppeteer.connect({ browserWSEndpoint })
 You can override the root URL to use some other set of docker images of Chromium and/or Firefox.
 
 
-Make sure the final link which is evaluated as `${dockerUrlRoot}/${browser}:${version}` points to a valid public docker image
+Make sure the final link, which is evaluated as `${dockerUrlRoot}/${browser}:${version}`, points to a docker image that is valid and public.
 
 ```js
 const { browserWSEndpoint, closeBrowser } = await runBrowser({

--- a/packages/xrom/readme.md
+++ b/packages/xrom/readme.md
@@ -42,7 +42,7 @@ const browser = await puppeteer.connect({ browserWSEndpoint })
 ```
 
 
-### Overriding the docker root url to another set of browser images
+### Overriding the docker root URL to another set of browser images
 You can override the root URL to use some other set of docker images of Chromium and/or Firefox.
 
 

--- a/packages/xrom/src/index.ts
+++ b/packages/xrom/src/index.ts
@@ -8,6 +8,7 @@ import { getDebuggerUrl } from './get-debugger-url'
 export type TRunBrowserOptions = {
   browser: 'chromium' | 'firefox',
   version: string,
+  dockerUrlRoot?: string
   port?: number,
   fontsDir?: string,
   mountVolumes?: {
@@ -52,15 +53,17 @@ export const runBrowser = async (options: TRunBrowserOptions): Promise<TRunBrows
     cmd += ` -v ${path.resolve(opts.fontsDir)}:/home/chromium/.fonts:delegated,ro`
   }
 
-  if (isNumber(options.cpus)) {
-    cmd += ` --cpus=${options.cpus}`
+  if (isNumber(opts.cpus)) {
+    cmd += ` --cpus=${opts.cpus}`
   }
 
-  if (isArray(options.cpusetCpus)) {
-    cmd += ` --cpuset-cpus=${options.cpusetCpus.join(',')}`
+  if (isArray(opts.cpusetCpus)) {
+    cmd += ` --cpuset-cpus=${opts.cpusetCpus.join(',')}`
   }
+  
+  const dockerImageURL = `${opts.dockerUrlRoot || 'nextools'}/${opts.browser}:${opts.version}`
 
-  cmd += ` --name ${containerName} nextools/${opts.browser}:${opts.version}`
+  cmd += ` --name ${containerName} ${dockerImageURL}`
 
   await spawnChildProcess(cmd, { stdout: null })
 


### PR DESCRIPTION
This adds the option for the end user to provide their own dockerUrlRoot to fetch chromium and/or firefox images from. so long as the link is similarly structured to [nextools/images](https://github.com/nextools/images)'s images


Example usage:
```js
const { browserWSEndpoint, closeBrowser } = await runBrowser({
  dockerUrlRoot: 'ghcr.io/shenato/docker-browser',
  browser: 'chromium',
  version: opts.chromiumVersion,
  fontsDir: opts.fontsDir,
})
```

The reason being that [nextools/images](https://github.com/nextools/images) doesn't support M1 chips and we would like to be able to use our forked version of it for now where we were able to add that support at the cost of not being able to publish to two registries anymore.

Perhaps in the future I can figure out how to add it without removing features from the original repository.